### PR TITLE
issue#35 - lookahead regex bug on quotes and crossboard quotes

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -2017,7 +2017,7 @@ function markup(&$body, $track_cites = false, $op = false) {
 	print_err("Cites BEGIN");
 
 	// Cites
-	if (isset($board) && preg_match_all('/(^|\s)&gt;&gt;(\d+?)([\s,.)?]|$)/m', $body, $cites, PREG_SET_ORDER | PREG_OFFSET_CAPTURE)) {
+	if (isset($board) && preg_match_all('/(^|\s)&gt;&gt;(\d+?)((?=[\s,.)?!])|$)/m', $body, $cites, PREG_SET_ORDER | PREG_OFFSET_CAPTURE)) {
 		if (count($cites[0]) > $config['max_cites']) {
 			error($config['error']['toomanycites']);
 		}
@@ -2067,7 +2067,7 @@ function markup(&$body, $track_cites = false, $op = false) {
 	print_err("Cross board linking BEGIN");
 
 	// Cross-board linking
-	if (preg_match_all('/(^|\s)&gt;&gt;&gt;\/(' . $config['board_regex'] . 'f?)\/(\d+)?([\s,.)?]|$)/um', $body, $cites, PREG_SET_ORDER | PREG_OFFSET_CAPTURE)) {
+	if (preg_match_all('/(^|\s)&gt;&gt;&gt;\/(' . $config['board_regex'] . 'f?)\/(\d+)?((?=[\s,.)?!])|$)/um', $body, $cites, PREG_SET_ORDER | PREG_OFFSET_CAPTURE)) {
 		if (count($cites[0]) > $config['max_cites']) {
 			error($config['error']['toomanycross']);
 		}


### PR DESCRIPTION
fix #35 

this changes the regex to fix the bug where people can't put a quote one space after another quote like this: >>999 >>998
without it breaking the second quote. Also fixes the same issue with crossboard quotes.