### PR TITLE
use mb_convert_encoding instead of iconv in slugify function in functions.php

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -2717,7 +2717,8 @@ function slugify($post) {
 	$slug = mb_convert_encoding($slug, "UTF-8", "UTF-8");
 
 	// Transliterate local characters like ü, I wonder how would it work for weird alphabets :^)
-	$slug = iconv("UTF-8", "ASCII//TRANSLIT//IGNORE", $slug);
+	// $slug = iconv("UTF-8", "ASCII//TRANSLIT//IGNORE", $slug);
+	$slug = mb_convert_encoding($slug, "ASCII", "UTF-8");
 
 	// Remove Tinyboard custom markup
 	$slug = preg_replace("/<tinyboard [^>]+>.*?<\/tinyboard>/s", '', $slug);


### PR DESCRIPTION
- possibly a fix for issue 23, at least for most common cases (there
  are other iconv usages still in the code)
    https://github.com/towards-a-new-leftypol/leftypol_lainchan/issues/23