### PR TITLE
Enable flags on the JSON api

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -111,7 +111,7 @@ class Api {
 		if ($threadsPage) return $apiPost;
 
 		// Handle country field
-		if (isset($post->body_nomarkup) && $this->config['country_flags']) {
+		if (isset($post->body_nomarkup) && ($this->config['country_flags'] || $this->config['user_flag'])) {
 			$modifiers = extract_modifiers($post->body_nomarkup);
 			if (isset($modifiers['flag']) && isset($modifiers['flag alt']) && preg_match('/^[1-9a-z_-]{2,}$/', $modifiers['flag'])) {
 				$country = strtolower($modifiers['flag']);

--- a/inc/api.php
+++ b/inc/api.php
@@ -113,8 +113,8 @@ class Api {
 		// Handle country field
 		if (isset($post->body_nomarkup) && $this->config['country_flags']) {
 			$modifiers = extract_modifiers($post->body_nomarkup);
-			if (isset($modifiers['flag']) && isset($modifiers['flag alt']) && preg_match('/^[a-z]{2}$/', $modifiers['flag'])) {
-				$country = strtoupper($modifiers['flag']);
+			if (isset($modifiers['flag']) && isset($modifiers['flag alt']) && preg_match('/^[1-9a-z_-]{2,}$/', $modifiers['flag'])) {
+				$country = strtolower($modifiers['flag']);
 				if ($country) {
 					$apiPost['country'] = $country;
 					$apiPost['country_name'] = $modifiers['flag alt'];
@@ -135,7 +135,7 @@ class Api {
 				$extra_files = array();
 				foreach ($post->files as $i => $f) {
 					if ($i == 0) continue;
-				
+
 					$extra_file = array();
 					$this->translateFile($f, $post, $extra_file);
 

--- a/inc/instance-config.php
+++ b/inc/instance-config.php
@@ -127,6 +127,7 @@ $config['allowed_ext_files'][] = 'epub';
  */
 $config['country_flags_condensed'] = false;
 $config['user_flag'] = true;
+$config['country_flags'] = true;
 $config['flag_style'] = 'width:auto;height:11px;';
 $config['user_flags'] = array (
     '4th_international' => '4th International',

--- a/inc/instance-config.php
+++ b/inc/instance-config.php
@@ -127,7 +127,6 @@ $config['allowed_ext_files'][] = 'epub';
  */
 $config['country_flags_condensed'] = false;
 $config['user_flag'] = true;
-$config['country_flags'] = true;
 $config['flag_style'] = 'width:auto;height:11px;';
 $config['user_flags'] = array (
     '4th_international' => '4th International',


### PR DESCRIPTION
Closes #68 

Threads have to be rebuilt in order for the json output to change.

The old behaviour was to only allow output of flags that only had 2 letters on their name (us, uk, ...). This commit changes that to allow 2 or more characters, including letters, numbers, `_` and `-`.