### PR TITLE
Add spoiler information to the API

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -93,6 +93,7 @@ class Api {
 		$dotPos = strrpos($file->file, '.');
 		$apiPost['ext'] = substr($file->file, $dotPos);
 		$apiPost['tim'] = substr($file->file, 0, $dotPos);
+		$apiPost['spoiler'] = $file->thumb === 'spoiler' ? 1 : 0;
 		if (isset ($file->hash) && $file->hash) {
 			$apiPost['md5'] = base64_encode(hex2bin($file->hash));
 		}


### PR DESCRIPTION
Adds spoiler information to files, so the mobile app can display them correctly

Using 1,0 rather than true,false keeps compatibility
with Clover/Kuroba's implementation of vichan's API parser