### PR TITLE
Disable antispam for now

### DIFF
--- a/inc/instance-config.php
+++ b/inc/instance-config.php
@@ -94,6 +94,16 @@ $config['root'] = '/';
 $config['secure_trip_salt'] = 'ODQ2NDM0ODlmMmRhNzk2M2EyNjJlOW';
 
 /*
+ * Some users are having trouble posting when this is on,
+ * with the message 'Your request looks automated; Post discarded.'
+ *
+ * This did not affect all users, and for some users only for some posts.
+ *
+ * If we are getting spammed hard, try turning this on.
+ */
+$config['spam']['enabled'] = false;
+
+/*
  * Permissions
  */
 $config['mod']['move'] = MOD;


### PR DESCRIPTION
- some users were having issues posting
- the issues are inconsistent. we should be careful with this feature,
    perhaps even log details of what went wrong when the error for this
    is shown and analyze those logs.

- one user said using a VPN let them post

TODO: @towards-a-new-leftypol  Make an issue for this