### PR TITLE
Replace Youtube embed

### DIFF
--- a/inc/instance-config.php
+++ b/inc/instance-config.php
@@ -346,6 +346,7 @@ $config['enable_embedding'] = true;
 
 $config['youtube_js_html'] = '<div class="video-container" data-video="$2">'.
 '<a href="https://youtu.be/$2" target="_blank" class="file">'.
+'https://youtu.be/$2'.
 '</a></div>';
 
 $config['embedding'] = array();

--- a/inc/instance-config.php
+++ b/inc/instance-config.php
@@ -346,7 +346,6 @@ $config['enable_embedding'] = true;
 
 $config['youtube_js_html'] = '<div class="video-container" data-video="$2">'.
 '<a href="https://youtu.be/$2" target="_blank" class="file">'.
-'<img style="width:255px;height:190px;" src="//img.youtube.com/vi/$2/0.jpg" class="post-image"/>'.
 '</a></div>';
 
 $config['embedding'] = array();

--- a/js/youtube.js
+++ b/js/youtube.js
@@ -25,21 +25,32 @@
 
 onready(function(){
 	var do_embed_yt = function(tag) {
-		$('div.video-container a', tag).click(function() {
-			var videoID = $(this.parentNode).data('video');
-		
-			$(this.parentNode).html('<iframe style="float:left;margin: 10px 20px" type="text/html" '+
-				'width="360" height="270" src="//www.youtube.com/embed/' + videoID +
-				'?autoplay=1&html5=1" allowfullscreen frameborder="0"/>');
+		const ON = "[Remove]";
+		const OFF = "[Embed]";
 
-			return false;
+		var videoNode = $('div.video-container', tag);
+		var videoId = videoNode.data('video');
+		var span = $("<span>[Embed]</span>");
+		var embedNode = $('<iframe style="float:left;margin: 10px 20px" type="text/html" '+
+				'width="360" height="270" src="//www.youtube.com/embed/' + videoId +
+				'?autoplay=1&html5=1" allowfullscreen frameborder="0"/>')
+		span.click(function() {
+			if (span.text() == ON){
+				videoNode.remove("iframe");
+				span.text(OFF);
+			} else{
+				videoNode.append(embedNode);
+				span.innerHTML = ON;
+			}
 		});
+
+		videoNode.append(span);
 	};
 	do_embed_yt(document);
 
-        // allow to work with auto-reload.js, etc.
-        $(document).on('new_post', function(e, post) {
-                do_embed_yt(post);
-        });
+	// allow to work with auto-reload.js, etc.
+	$(document).on('new_post', function(e, post) {
+			do_embed_yt(post);
+	});
 });
 

--- a/js/youtube.js
+++ b/js/youtube.js
@@ -40,7 +40,7 @@ onready(function(){
 				span.text(OFF);
 			} else{
 				videoNode.append(embedNode);
-				span.innerHTML = ON;
+				span.text(ON);
 			}
 		});
 

--- a/js/youtube.js
+++ b/js/youtube.js
@@ -36,7 +36,7 @@ onready(function(){
 				'?autoplay=1&html5=1" allowfullscreen frameborder="0"/>')
 		span.click(function() {
 			if (span.text() == ON){
-				videoNode.remove("iframe");
+				embedNode.remove();
 				span.text(OFF);
 			} else{
 				videoNode.append(embedNode);


### PR DESCRIPTION
Embedding currently makes calls to youtube to get the preview image. This leaks activity to youtube's servers and users have requested to remove this functionality. In it's place, this PR removes the preview, substitutes it with the youtube link, and adds an [Embed] button that when clicked, embeds the youtube video in the page. A similar functionality exists on lynxchan. 