### PR TITLE
securimage in webconfig

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -31,6 +31,8 @@
  * =======================
  */
 
+    $config['securimage'] = false;
+
     // Global announcement -- the very simple version.
     // This used to be wrongly named $config['blotter'] (still exists as an alias).
     // $config['global_message'] = 'This is an important announcement!';


### PR DESCRIPTION
Make sure securimage option (to enable captcha) can be set in web configuration,
by adding the default (false) to config.php