### PR TITLE
WebP thumbnails

### DIFF
--- a/inc/image.php
+++ b/inc/image.php
@@ -312,7 +312,7 @@ class ImageConvert extends ImageBase {
 			$this->destroy();
 		}
 		
-		$this->temp = tempnam($config['tmp'], 'convert');
+		$this->temp = tempnam($config['tmp'], 'convert') . ($config['thumb_ext'] == '' ? '' : '.' . $config['thumb_ext']);
 				
 		$config['thumb_keep_animation_frames'] = (int)$config['thumb_keep_animation_frames'];
 		

--- a/inc/instance-config.php
+++ b/inc/instance-config.php
@@ -151,6 +151,7 @@ $config['max_images'] = 5;
 $config['image_reject_repost'] = false;
 
 $config['thumb_method'] = 'gm+gifsicle';
+$config['thumb_ext'] = 'webp';
 $config['gnu_md5'] = '1';
 // $config['update_on_posts'] = true;
 $config['referer_match'] = false;


### PR DESCRIPTION
Deliver thumbnails as WebP images.
WebP is now supported by all major browsers and is unlikely to break thumbnails for anyone, even those with anti-WebP extensions.

This only applies to thumbnails, .webp are still not valid attachments due to them being unsupported by many softwares including common file viewers

This format should be replaced with AVIF or JPEG XL once they become widely available.