### PR TITLE
'Expand on image hover' option

### DIFF
--- a/inc/instance-config.php
+++ b/inc/instance-config.php
@@ -370,6 +370,7 @@ $config['additional_javascript'][] = 'js/auto-reload.js';
 $config['additional_javascript'][] = 'js/auto-scroll.js';
 $config['additional_javascript'][] = 'js/thread-stats.js';
 $config['additional_javascript'][] = 'js/post-hover.js';
+$config['additional_javascript'][] = 'js/image-hover.js';
 $config['additional_javascript'][] = 'js/style-select.js';
 $config['additional_javascript'][] = 'js/flag-preview.js';
 

--- a/js/image-hover.js
+++ b/js/image-hover.js
@@ -13,7 +13,7 @@ if (window.Options && Options.get_tab('general')) {
 	+ ("<label class='image-hover' id='imageHover'><input type='checkbox' /> "+_('Image hover')+"</label>")
 	+ ("<label class='image-hover' id='catalogImageHover'><input type='checkbox' /> "+_('Image hover on catalog')+"</label>")
 	+ ("<label class='image-hover' id='imageHoverFollowCursor'><input type='checkbox' /> "+_('Image hover should follow cursor')+"</label>")
-	+ "</fieldset>");console.log("aaa");
+	+ "</fieldset>");
 }
 
 $('.image-hover').on('change', function(){
@@ -70,7 +70,7 @@ function initImageHover() { //Pashe, influenced by tux, et al, WTFPL
 	if (!getSetting("imageHover") && !getSetting("catalogImageHover")) {return;}
 	
 	var selectors = [];
-		console.log("image-hover");
+	
 	if (getSetting("imageHover")) {selectors.push("img.post-image", "canvas.post-image");}
 	if (getSetting("catalogImageHover") && isOnCatalog()) {
 		selectors.push(".thread-image");


### PR DESCRIPTION
Fix and enable image hover, an option for having images expand when you hover over them, similar to GETchan's default behavior.
This is currently not enabled for the user by default.  They must turn it on in the options menu.