### PR TITLE
Move unique IPs to right

### DIFF
--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -1331,6 +1331,11 @@ div.boardlist {
 	float: right;
 }
 
+#uniqueip > span {
+	float:   right;
+	margin:  0em 1em;
+}
+
 #post-moderation-fields {
 	float: right;
 	text-align: right;


### PR DESCRIPTION
This moves it next to the thread stats.
Courtesy of based hornyposter.
Closes https://github.com/towards-a-new-leftypol/leftypol_lainchan/issues/230