### PR TITLE
Applies lazy loading to img tags on post replies

### DIFF
--- a/inc/instance-config.php
+++ b/inc/instance-config.php
@@ -410,6 +410,8 @@ $config['additional_javascript_defer'][] = 'js/expand.js';
 $config['additional_javascript_defer'][] = 'js/webm-settings.js';
 $config['additional_javascript_defer'][] = 'js/expand-video.js';
 
+$config['additional_javascript_defer'][] = 'js/remove-lazy-loading.js';
+
 $config['additional_javascript'] = array_merge($config['additional_javascript_init'], $config['additional_javascript_defer']);
 
 $config['flag_preview'] = true;

--- a/js/remove-lazy-loading.js
+++ b/js/remove-lazy-loading.js
@@ -20,7 +20,9 @@
 
 function removeLazyLoading(){
 	if(document.readyState === "complete"){
-		$(".post-image").removeAttr("loading")
+		setTimeOut(
+			() => $(".post-image").removeAttr("loading")
+			, 500)
 	} else {
 		$(window).on("load", removeLazyLoading)
 	}

--- a/js/remove-lazy-loading.js
+++ b/js/remove-lazy-loading.js
@@ -1,0 +1,29 @@
+/*
+ * remove-lazy-loading.js - Removes lazy loading from thread reply images to force them to eagerly load. 
+ * Lazy loading of images helps render threads quicker, but this means that images will only be loaded on scroll.
+ * This impacts the user experience in a negative way since they will often see blank images when scrolling 
+ * while the thumbnails load. This js solves this problem by allowing images to deferred and loaded lazily, 
+ * and once everything has loaded, eagerly load the images at once by removing the lazy attribute.
+ *
+ *
+ * Copyleft (ɔ) 2021 Leftypol Moderation Team
+ *
+ * Usage:
+ *	// if deferred js is implemented and enabled:
+ *	// (see: https://github.com/towards-a-new-leftypol/leftypol_lainchan/pull/308/commits/dca55a16431591b3e8615320e7b78ee3e0e747b7 ):
+ *   $config['additional_javascript_defer'][] = 'js/webm-settings.js';
+ *	// otherwise:
+ * 	$config['additional_javascript'][] = 'js/style-select.js'
+ *
+ */
+
+
+function removeLazyLoading(){
+	if(document.readyState === "complete"){
+		$(".post-image").removeAttr("loading")
+	} else {
+		$(window).on("load", removeLazyLoading)
+	}
+}
+
+$(removeLazyLoading);

--- a/js/remove-lazy-loading.js
+++ b/js/remove-lazy-loading.js
@@ -20,9 +20,7 @@
 
 function removeLazyLoading(){
 	if(document.readyState === "complete"){
-		setTimeOut(
-			() => $(".post-image").removeAttr("loading")
-			, 500)
+		$(".post-image").removeAttr("loading")
 	} else {
 		$(window).on("load", removeLazyLoading)
 	}

--- a/js/remove-lazy-loading.js
+++ b/js/remove-lazy-loading.js
@@ -9,11 +9,7 @@
  * Copyleft (ɔ) 2021 Leftypol Moderation Team
  *
  * Usage:
- *	// if deferred js is implemented and enabled:
- *	// (see: https://github.com/towards-a-new-leftypol/leftypol_lainchan/pull/308/commits/dca55a16431591b3e8615320e7b78ee3e0e747b7 ):
- *   $config['additional_javascript_defer'][] = 'js/webm-settings.js';
- *	// otherwise:
- * 	$config['additional_javascript'][] = 'js/style-select.js'
+ * 	$config['additional_javascript'][] = 'js/remove-lazy-loading.js'
  *
  */
 

--- a/templates/header.html
+++ b/templates/header.html
@@ -56,3 +56,8 @@
 				padding: 0 !important;
 			}
 		{% endraw %}</style>{% endif %}
+		<noscript>
+			<style type="text/css">
+				.no-script-no-display {display: none;}
+			</style>
+		</noscript>

--- a/templates/post/image.html
+++ b/templates/post/image.html
@@ -24,7 +24,7 @@
 		>
 		</video>
 	{% else %}
-		{% macro image(doLazy) %}
+		{% macro tag(doLazy) %}
 			<img class="post-image" 
 			{% if doLazy %}
 				loading="lazy"

--- a/templates/post/image.html
+++ b/templates/post/image.html
@@ -27,7 +27,7 @@
 		{% macro tag(doLazy, config, post) %}
 			<img 
 			class="post-image {{ doLazy ? 'no-script-no-display'}}" 
-			{{ doLazy ? loading="lazy" }}
+			{{ doLazy ? 'loading="lazy"' }}
 			src="
 				{% if post.thumb == 'file' %}
 					{{ config.root }}

--- a/templates/post/image.html
+++ b/templates/post/image.html
@@ -24,8 +24,9 @@
 		>
 		</video>
 	{% else %}
-		<img class="post-image" 
-			{% if 'js/remove-lazy-loading.js' in config.additional_javascript or 'js/remove-lazy-loading.js' in config.additional_javascript_defer %}
+		{% macro image(isScript) %}
+			<img class="post-image" 
+			{% if isScript and 'js/remove-lazy-loading.js' in config.additional_javascript or 'js/remove-lazy-loading.js' in config.additional_javascript_defer %}
 				loading="lazy"
 			{% endif %}
 			src="
@@ -43,6 +44,13 @@
 				{% endif %}
 			"
 			 style="width:{{ post.thumbwidth }}px;height:{{ post.thumbheight }}px" alt="" 
-		/>
+			/>
+		{% endmacro %}
+		<script>
+			{{image(true)}}
+		</script>
+		<noscript>
+			{{image(false)}}
+		</noscript>
 	{% endif %}
 </a>

--- a/templates/post/image.html
+++ b/templates/post/image.html
@@ -24,7 +24,7 @@
 		>
 		</video>
 	{% else %}
-		{% macro tag(doLazy) %}
+		{% macro tag(doLazy, config, post) %}
 			<img class="post-image" 
 			{% if doLazy %}
 				loading="lazy"
@@ -49,13 +49,13 @@
 		{% import _self as image %}
 		{% if 'js/remove-lazy-loading.js' in config.additional_javascript or 'js/remove-lazy-loading.js' in config.additional_javascript_defer %}
 			<script>
-				{{image.tag(true)}}
+				{{image.tag(true, config, post)}}
 			</script>
 			<noscript>
-				{{image.tag(false)}}
+				{{image.tag(false, config, post)}}
 			</noscript>
 		{% else %}
-			{{image.tag(false)}}
+			{{image.tag(false, config, post)}}
 		{% endif %}
 	{% endif %}
 </a>

--- a/templates/post/image.html
+++ b/templates/post/image.html
@@ -25,10 +25,9 @@
 		</video>
 	{% else %}
 		{% macro tag(doLazy, config, post) %}
-			<img class="post-image" 
-			{% if doLazy %}
-				loading="lazy"
-			{% endif %}
+			<img 
+			class="post-image {{ doLazy ? 'no-script-no-display'}}" 
+			{{ doLazy ? loading="lazy" }}
 			src="
 				{% if post.thumb == 'file' %}
 					{{ config.root }}
@@ -48,9 +47,7 @@
 		{% endmacro %}
 		{% import _self as image %}
 		{% if 'js/remove-lazy-loading.js' in config.additional_javascript or 'js/remove-lazy-loading.js' in config.additional_javascript_defer %}
-			<script>
-				{{image.tag(true, config, post)}}
-			</script>
+			{{image.tag(true, config, post)}}
 			<noscript>
 				{{image.tag(false, config, post)}}
 			</noscript>

--- a/templates/post/image.html
+++ b/templates/post/image.html
@@ -24,7 +24,10 @@
 		>
 		</video>
 	{% else %}
-		<img class="post-image" loading="lazy"
+		<img class="post-image" 
+			{% if 'js/remove-lazy-loading.js' in config.additional_javascript|merge(config.additional_javascript_defer) %}
+				loading="lazy"
+			{% endif %}
 			src="
 				{% if post.thumb == 'file' %}
 					{{ config.root }}

--- a/templates/post/image.html
+++ b/templates/post/image.html
@@ -26,23 +26,23 @@
 	{% else %}
 		{% macro tag(doLazy, config, post) %}
 			<img 
-			class="post-image {{ doLazy ? 'no-script-no-display'}}" 
-			{{ doLazy ? 'loading="lazy"' }}
-			src="
-				{% if post.thumb == 'file' %}
-					{{ config.root }}
-					{% if config.file_icons[post.filename|extension] %}
-						{{ config.file_thumb|sprintf(config.file_icons[post.filename|extension]) }}
+				class="post-image {{ doLazy ? 'no-script-no-display'}}" 
+				{{ doLazy ? 'loading="lazy"' }}
+				src="
+					{% if post.thumb == 'file' %}
+						{{ config.root }}
+						{% if config.file_icons[post.filename|extension] %}
+							{{ config.file_thumb|sprintf(config.file_icons[post.filename|extension]) }}
+						{% else %}
+							{{ config.file_thumb|sprintf(config.file_icons.default) }}
+						{% endif %}
+					{% elseif post.thumb == 'spoiler' %}
+						{{ config.root }}{{ config.spoiler_image }}
 					{% else %}
-						{{ config.file_thumb|sprintf(config.file_icons.default) }}
+						{{ config.uri_thumb }}{{ post.thumb }}
 					{% endif %}
-				{% elseif post.thumb == 'spoiler' %}
-					{{ config.root }}{{ config.spoiler_image }}
-				{% else %}
-					{{ config.uri_thumb }}{{ post.thumb }}
-				{% endif %}
-			"
-			 style="width:{{ post.thumbwidth }}px;height:{{ post.thumbheight }}px" alt="" 
+				"
+				style="width:{{ post.thumbwidth }}px;height:{{ post.thumbheight }}px" alt="" 
 			/>
 		{% endmacro %}
 		{% import _self as image %}

--- a/templates/post/image.html
+++ b/templates/post/image.html
@@ -25,7 +25,7 @@
 		</video>
 	{% else %}
 		<img class="post-image" 
-			{% if 'js/remove-lazy-loading.js' in config.additional_javascript|merge(config.additional_javascript_defer) %}
+			{% if 'js/remove-lazy-loading.js' in config.additional_javascript or 'js/remove-lazy-loading.js' in config.additional_javascript_defer %}
 				loading="lazy"
 			{% endif %}
 			src="

--- a/templates/post/image.html
+++ b/templates/post/image.html
@@ -24,9 +24,9 @@
 		>
 		</video>
 	{% else %}
-		{% macro image(isScript) %}
+		{% macro image(doLazy) %}
 			<img class="post-image" 
-			{% if isScript and 'js/remove-lazy-loading.js' in config.additional_javascript or 'js/remove-lazy-loading.js' in config.additional_javascript_defer %}
+			{% if doLazy %}
 				loading="lazy"
 			{% endif %}
 			src="
@@ -46,11 +46,16 @@
 			 style="width:{{ post.thumbwidth }}px;height:{{ post.thumbheight }}px" alt="" 
 			/>
 		{% endmacro %}
-		<script>
-			{{image(true)}}
-		</script>
-		<noscript>
-			{{image(false)}}
-		</noscript>
+		{% import _self as image %}
+		{% if 'js/remove-lazy-loading.js' in config.additional_javascript or 'js/remove-lazy-loading.js' in config.additional_javascript_defer %}
+			<script>
+				{{image.tag(true)}}
+			</script>
+			<noscript>
+				{{image.tag(false)}}
+			</noscript>
+		{% else %}
+			{{image.tag(false)}}
+		{% endif %}
 	{% endif %}
 </a>

--- a/templates/post/image.html
+++ b/templates/post/image.html
@@ -24,7 +24,7 @@
 		>
 		</video>
 	{% else %}
-		<img class="post-image" 
+		<img class="post-image" loading="lazy"
 			src="
 				{% if post.thumb == 'file' %}
 					{{ config.root }}


### PR DESCRIPTION
#Motivation:
Throttling: Regular 4G on Firefox, cache disabled. 

With lazy loading:
<img width="248" alt="image" src="https://user-images.githubusercontent.com/63084025/125525750-3d222779-3647-4b5a-a37b-d7a594aa6f4a.png">

Without
<img width="244" alt="image" src="https://user-images.githubusercontent.com/63084025/125525783-5eb0adb1-b994-4148-a894-1413884d17dc.png">
