### PR TITLE
Set update-checking to false by default

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -40,7 +40,7 @@
     $config['blotter'] = &$config['global_message'];
 
     // Automatically check if a newer version of Tinyboard is available when an administrator logs in.
-    $config['check_updates'] = true;
+    $config['check_updates'] = false;
     // How often to check for updates
     $config['check_updates_time'] = 43200; // 12 hours
 


### PR DESCRIPTION
This is an obsoleted feature which hypothetically can be abused

This should later be followed up by removing the update entire code.