### PR TITLE
Change public Tinyboard and vichan links

### DIFF
--- a/templates/generic_page.html
+++ b/templates/generic_page.html
@@ -39,11 +39,11 @@
 	{% endfor %} {{ btn.next }}</div>
 	{{ boardlist.bottom }}
 	<footer>
-		<p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="http://tinyboard.org/">Tinyboard</a> + 
-			<a href='https://int.vichan.net/devel/'>vichan</a> + 
+		<p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="https://github.com/savetheinternet/Tinyboard">Tinyboard</a> + 
+			<a href='https://github.com/vichan-devel/vichan'>vichan</a> + 
 			<a href='https://github.com/lainchan/lainchan'>lainchan</a> {{ config.version }} -
-		<br><a href="http://tinyboard.org/">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
-		<br><a href="https://engine.vichan.net/">vichan</a> Copyright &copy; 2012-2016 vichan-devel
+		<br><a href="https://github.com/savetheinternet/Tinyboard">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
+		<br><a href="https://github.com/vichan-devel/vichan">vichan</a> Copyright &copy; 2012-2016 vichan-devel
 		<br><a href="https://github.com/lainchan/lainchan">lainchan</a> Copyright &copy; 2014-2017 lainchan Administration</p>
 
 		{% for footer in config.footer %}<p class="unimportant" style="text-align:center;">{{ footer }}</p>{% endfor %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -85,11 +85,11 @@
 	<footer>
 		<p>&nbsp;</p>
 		<p>&nbsp;</p>
-		<p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="http://tinyboard.org/">Tinyboard</a> + 
-			<a href='https://int.vichan.net/devel/'>vichan</a> + 
+		<p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="https://github.com/savetheinternet/Tinyboard">Tinyboard</a> + 
+			<a href='https://github.com/vichan-devel/vichan'>vichan</a> + 
 			<a href='https://github.com/lainchan/lainchan'>lainchan</a> {{ config.version }} -
-		<br><a href="http://tinyboard.org/">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
-		<br><a href="https://engine.vichan.net/">vichan</a> Copyright &copy; 2012-2016 vichan-devel
+		<br><a href="https://github.com/savetheinternet/Tinyboard">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
+		<br><a href="https://github.com/vichan-devel/vichan">vichan</a> Copyright &copy; 2012-2016 vichan-devel
 		<br><a href="https://github.com/lainchan/lainchan">lainchan</a> Copyright &copy; 2014-2017 lainchan Administration</p>
 
 		{% for footer in config.footer %}<p class="unimportant" style="text-align:center;">{{ footer }}</p>{% endfor %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -26,11 +26,11 @@
 	{{ body }}
 	<hr>
 	<footer>
-		<p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="http://tinyboard.org/">Tinyboard</a> + 
-			<a href='https://int.vichan.net/devel/'>vichan</a> + 
+		<p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="https://github.com/savetheinternet/Tinyboard">Tinyboard</a> + 
+			<a href='https://github.com/vichan-devel/vichan'>vichan</a> + 
 			<a href='https://github.com/lainchan/lainchan'>lainchan</a> {{ config.version }} -
-		<br><a href="http://tinyboard.org/">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
-		<br><a href="https://engine.vichan.net/">vichan</a> Copyright &copy; 2012-2016 vichan-devel
+		<br><a href="https://github.com/savetheinternet/Tinyboard">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
+		<br><a href="https://github.com/vichan-devel/vichan">vichan</a> Copyright &copy; 2012-2016 vichan-devel
 		<br><a href="https://github.com/lainchan/lainchan">lainchan</a> Copyright &copy; 2014-2017 lainchan Administration</p>
 
 	</footer>

--- a/templates/themes/calendar/calendar.html
+++ b/templates/themes/calendar/calendar.html
@@ -28,11 +28,11 @@
 	
 	<hr/>
         <footer>
-		<p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="http://tinyboard.org/">Tinyboard</a> + 
-			<a href='https://int.vichan.net/devel/'>vichan</a> + 
+		<p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="https://github.com/savetheinternet/Tinyboard">Tinyboard</a> + 
+			<a href='https://github.com/vichan-devel/vichan'>vichan</a> + 
 			<a href='https://github.com/lainchan/lainchan'>lainchan</a> {{ config.version }} -
-		<br><a href="http://tinyboard.org/">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
-		<br><a href="https://engine.vichan.net/">vichan</a> Copyright &copy; 2012-2016 vichan-devel
+		<br><a href="https://github.com/savetheinternet/Tinyboard">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
+		<br><a href="https://github.com/vichan-devel/vichan">vichan</a> Copyright &copy; 2012-2016 vichan-devel
 		<br><a href="https://github.com/lainchan/lainchan">lainchan</a> Copyright &copy; 2014-2017 lainchan Administration</p>
         </footer>
 	<div class="pages"></div>

--- a/templates/themes/catalog/catalog.html
+++ b/templates/themes/catalog/catalog.html
@@ -91,10 +91,12 @@
 
 	<hr/>
 	<footer>
-		<p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="http://tinyboard.org/">Tinyboard</a> +
-			<a href='https://int.vichan.net/devel/'>vichan</a> {{ config.version }} -
-		<br><a href="http://tinyboard.org/">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
-		<br><a href="https://engine.vichan.net/">vichan</a> Copyright &copy; 2012-2015 vichan-devel</p>
+		<p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="https://github.com/savetheinternet/Tinyboard">Tinyboard</a> + 
+			<a href='https://github.com/vichan-devel/vichan'>vichan</a> + 
+			<a href='https://github.com/lainchan/lainchan'>lainchan</a> {{ config.version }} -
+		<br><a href="https://github.com/savetheinternet/Tinyboard">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
+		<br><a href="https://github.com/vichan-devel/vichan">vichan</a> Copyright &copy; 2012-2016 vichan-devel
+		<br><a href="https://github.com/lainchan/lainchan">lainchan</a> Copyright &copy; 2014-2017 lainchan Administration</p>
 	</footer>
 	<div class="pages"></div>
 

--- a/templates/themes/staffapplication/staffapplication.html
+++ b/templates/themes/staffapplication/staffapplication.html
@@ -64,11 +64,11 @@
 	
 	<hr/>
         <footer>
-		<p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="http://tinyboard.org/">Tinyboard</a> + 
-			<a href='https://int.vichan.net/devel/'>vichan</a> + 
+		<p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="https://github.com/savetheinternet/Tinyboard">Tinyboard</a> + 
+			<a href='https://github.com/vichan-devel/vichan'>vichan</a> + 
 			<a href='https://github.com/lainchan/lainchan'>lainchan</a> {{ config.version }} -
-		<br><a href="http://tinyboard.org/">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
-		<br><a href="https://engine.vichan.net/">vichan</a> Copyright &copy; 2012-2016 vichan-devel
+		<br><a href="https://github.com/savetheinternet/Tinyboard">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
+		<br><a href="https://github.com/vichan-devel/vichan">vichan</a> Copyright &copy; 2012-2016 vichan-devel
 		<br><a href="https://github.com/lainchan/lainchan">lainchan</a> Copyright &copy; 2014-2017 lainchan Administration</p>
         </footer>
 	<div class="pages"></div>

--- a/templates/themes/stream/stream.html
+++ b/templates/themes/stream/stream.html
@@ -166,10 +166,12 @@ function change_format(e) {
 	
 	<hr/>
         <footer>
-                <p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="http://tinyboard.org/">Tinyboard</a> + 
-                        <a href='https://int.vichan.net/devel/'>vichan</a> {{ config.version }} -
-                <br><a href="http://tinyboard.org/">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group    
-                <br><a href="https://engine.vichan.net/">vichan</a> Copyright &copy; 2012-2015 vichan-devel</p>
+		<p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="https://github.com/savetheinternet/Tinyboard">Tinyboard</a> + 
+			<a href='https://github.com/vichan-devel/vichan'>vichan</a> + 
+			<a href='https://github.com/lainchan/lainchan'>lainchan</a> {{ config.version }} -
+		<br><a href="https://github.com/savetheinternet/Tinyboard">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
+		<br><a href="https://github.com/vichan-devel/vichan">vichan</a> Copyright &copy; 2012-2016 vichan-devel
+		<br><a href="https://github.com/lainchan/lainchan">lainchan</a> Copyright &copy; 2014-2017 lainchan Administration</p>
         </footer>
 	<div class="pages"></div>
 	<script type="text/javascript">{% raw %}

--- a/templates/thread.html
+++ b/templates/thread.html
@@ -95,11 +95,11 @@
 
 	<footer>
 		{% include 'badges.html' %}
-		<p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="http://tinyboard.org/">Tinyboard</a> + 
-			<a href='https://int.vichan.net/devel/'>vichan</a> + 
+		<p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="https://github.com/savetheinternet/Tinyboard">Tinyboard</a> + 
+			<a href='https://github.com/vichan-devel/vichan'>vichan</a> + 
 			<a href='https://github.com/lainchan/lainchan'>lainchan</a> {{ config.version }} -
-		<br><a href="http://tinyboard.org/">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
-		<br><a href="https://engine.vichan.net/">vichan</a> Copyright &copy; 2012-2016 vichan-devel
+		<br><a href="https://github.com/savetheinternet/Tinyboard">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
+		<br><a href="https://github.com/vichan-devel/vichan">vichan</a> Copyright &copy; 2012-2016 vichan-devel
 		<br><a href="https://github.com/lainchan/lainchan">lainchan</a> Copyright &copy; 2014-2017 lainchan Administration</p>
 		{% for footer in config.footer %}<p class="unimportant" style="text-align:center;">{{ footer }}</p>{% endfor %}
 	</footer>

--- a/templates/thread2_old.html
+++ b/templates/thread2_old.html
@@ -95,11 +95,11 @@
 
 	<footer>
 		{% include 'badges.html' %}
-		<p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="http://tinyboard.org/">Tinyboard</a> + 
-			<a href='https://int.vichan.net/devel/'>vichan</a> + 
+		<p class="unimportant" style="margin-top:20px;text-align:center;">- <a href="https://github.com/savetheinternet/Tinyboard">Tinyboard</a> + 
+			<a href='https://github.com/vichan-devel/vichan'>vichan</a> + 
 			<a href='https://github.com/lainchan/lainchan'>lainchan</a> {{ config.version }} -
-		<br><a href="http://tinyboard.org/">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
-		<br><a href="https://engine.vichan.net/">vichan</a> Copyright &copy; 2012-2016 vichan-devel
+		<br><a href="https://github.com/savetheinternet/Tinyboard">Tinyboard</a> Copyright &copy; 2010-2014 Tinyboard Development Group
+		<br><a href="https://github.com/vichan-devel/vichan">vichan</a> Copyright &copy; 2012-2016 vichan-devel
 		<br><a href="https://github.com/lainchan/lainchan">lainchan</a> Copyright &copy; 2014-2017 lainchan Administration</p>
 		{% for footer in config.footer %}<p class="unimportant" style="text-align:center;">{{ footer }}</p>{% endfor %}
 	</footer>


### PR DESCRIPTION
The tinyboard.org domain has been hijacked to redirect to a generic phishing site. This issue is also foreseeable with vichan.net
This change replaces the public-facing links to these homepages with their GitHub repositories.

(The links in documentation and code should also be replaced with archived links or removed, although this is less critical)