### PR TITLE
Remove duplicate scripts

### DIFF
--- a/inc/instance-config.php
+++ b/inc/instance-config.php
@@ -372,9 +372,7 @@ $config['default_stylesheet'] = array('Dark Red', $config['stylesheets']['Dark R
  */
 
 $config['deferred_javascript'] = true;
-$config['additional_javascript'][] = 'js/jquery.min.js';
 $config['additional_javascript'][] = 'js/jquery-ui.custom.min.js';
-$config['additional_javascript'][] = 'js/inline-expanding.js';
 $config['additional_javascript'][] = 'js/ajax.js';
 $config['additional_javascript'][] = 'js/quick-reply.js';
 $config['additional_javascript'][] = 'js/post-hover.js';


### PR DESCRIPTION
These scripts are already enabled by default in config.php, which lead to adverse behavior (double registration of listeners and duplicate options gui spans).

Courtesy of based hornyposter.