### PR TITLE
Remove additonal scripts

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -1037,9 +1037,6 @@
  */
 
     // Additional Javascript files to include on board index and thread pages. See js/ for available scripts.
-    $config['additional_javascript'][] = 'js/jquery.min.js';
-    $config['additional_javascript'][] = 'js/inline-expanding.js';
-    // $config['additional_javascript'][] = 'js/local-time.js';
 
     // Some scripts require jQuery. Check the comments in script files to see what's needed. When enabling
     // jQuery, you should first empty the array so that "js/query.min.js" can be the first, and then re-add


### PR DESCRIPTION
Normalizing the loading of additional scripts in config.php (such as inline-expanding.js) before other scripts such as the options.js scripts causes loading issues. There is no need for certain non-essential scripts to be enabled in the default config file. Our recommendations are made clear by our instance-config.php.

In our case, these scripts were loaded twice, which lead to adverse behavior (double registration of listeners and duplicate options gui spans).

Courtesy of based hornyposter.