### PR TITLE
vichan downstream: Feature: Staged Early 404 

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -558,9 +558,11 @@
     // Enable early 404? With default settings, a thread would 404 if it was to leave page 3, if it had less
     // than 3 replies.
     $config['early_404'] = false;
-
     $config['early_404_page'] = 3;
     $config['early_404_replies'] = 5;
+    // Early 404 in stages. With default settings, a thread would 404 if leaving page 3 on less than 9 replies
+    // or leaving 4 with less than 12 replies, 5 on less than 15 replies, etc.
+ 	$config['early_404_staged'] = false;
 
     // A wordfilter (sometimes referred to as just a "filter" or "censor") automatically scans users’ posts
     // as they are submitted and changes or censors particular words or phrases.

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1296,10 +1296,27 @@ function clean($pid = false) {
 		$query->bindValue(':offset', $offset, PDO::PARAM_INT);
 		$query->execute() or error(db_error($query));
 		
+		if ($config['early_404_staged']) {
+			$page = $config['early_404_page'];
+			$iter = 0;
+		}
+		else {
+			$page = 1;
+		}
+
 		while ($post = $query->fetch(PDO::FETCH_ASSOC)) {
-			if ($post['reply_count'] < $config['early_404_replies']) {
+			if ($post['reply_count'] < $page*$config['early_404_replies']) {
 				deletePost($post['thread_id'], false, false);
 				if ($pid) modLog("Automatically deleting thread #{$post['thread_id']} due to new thread #{$pid} (early 404 is set, #{$post['thread_id']} had {$post['reply_count']} replies)");
+			}
+
+			if ($config['early_404_staged']) {
+				$iter++;
+
+				if ($iter == $config['threads_per_page']) {
+					$page++;
+					$iter = 0;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
(We don't use this)

Allows an option where threads can be pruned early if they don't receive a certain number of replies, with that number increasing as they fall down each page.