### PR TITLE
Fix moving/merging posts with spoiler, deleted or non-image files

### DIFF
--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -1234,8 +1234,10 @@ function mod_move_reply($originBoard, $postID) {
             $post['files'] = json_decode($post['files'], TRUE);
             $post['has_file'] = true;
             foreach ($post['files'] as $i => &$file) {
-                $file['file_path'] = sprintf($config['board_path'], $board['uri']) . $config['dir']['img'] . $file['file'];
-                $file['thumb_path'] = sprintf($config['board_path'], $board['uri']) . $config['dir']['thumb'] . $file['thumb'];
+                if ($file['file'] !== 'deleted')
+                    $file['file_path'] = sprintf($config['board_path'], $board['uri']) . $config['dir']['img'] . $file['file'];
+                if (isset($file['thumb']) && !in_array($file['thumb'], array('spoiler', 'deleted', 'file')))
+                    $file['thumb_path'] = sprintf($config['board_path'], $board['uri']) . $config['dir']['thumb'] . $file['thumb'];
             }
         } else {
             $post['has_file'] = false;
@@ -1253,10 +1255,10 @@ function mod_move_reply($originBoard, $postID) {
         if ($post['has_file']) {
             foreach ($post['files'] as $i => &$file) {
                 // move the image
-                rename($file['file_path'], sprintf($config['board_path'], $board['uri']) . $config['dir']['img'] . $file['file']);
-                if ($file['thumb'] != 'spoiler') { //trying to move/copy the spoiler thumb raises an error
+                if ($file['file'] !== 'deleted')
+                    rename($file['file_path'], sprintf($config['board_path'], $board['uri']) . $config['dir']['img'] . $file['file']);
+                if (isset($file['thumb']) && !in_array($file['thumb'], array('spoiler', 'deleted', 'file')))
                     rename($file['thumb_path'], sprintf($config['board_path'], $board['uri']) . $config['dir']['thumb'] . $file['thumb']);
-                }
             }
         }
 
@@ -1334,10 +1336,10 @@ function mod_move($originBoard, $postID) {
             $post['files'] = json_decode($post['files'], TRUE);
             $post['has_file'] = true;
             foreach ($post['files'] as $i => &$file) {
-                if ($file['file'] === 'deleted')
-                    continue;
-                $file['file_path'] = sprintf($config['board_path'], $board['uri']) . $config['dir']['img'] . $file['file'];
-                $file['thumb_path'] = sprintf($config['board_path'], $board['uri']) . $config['dir']['thumb'] . $file['thumb'];
+                if ($file['file'] !== 'deleted')
+                    $file['file_path'] = sprintf($config['board_path'], $board['uri']) . $config['dir']['img'] . $file['file'];
+                if (isset($file['thumb']) && !in_array($file['thumb'], array('spoiler', 'deleted', 'file')))
+                    $file['thumb_path'] = sprintf($config['board_path'], $board['uri']) . $config['dir']['thumb'] . $file['thumb'];
             }
         } else {
             $post['has_file'] = false;
@@ -1382,12 +1384,10 @@ function mod_move($originBoard, $postID) {
                 $post['files'] = json_decode($post['files'], TRUE);
                 $post['has_file'] = true;
                 foreach ($post['files'] as $i => &$file) {
-                    if ($file['file'] !== 'deleted') {
+                    if ($file['file'] !== 'deleted')
                         $file['file_path'] = sprintf($config['board_path'], $board['uri']) . $config['dir']['img'] . $file['file'];
-                    }
-                    if (isset($file['thumb']) && !in_array($file['thumb'], array('spoiler', 'deleted', 'file'))) {
+                    if (isset($file['thumb']) && !in_array($file['thumb'], array('spoiler', 'deleted', 'file')))
                         $file['thumb_path'] = sprintf($config['board_path'], $board['uri']) . $config['dir']['thumb'] . $file['thumb'];
-                    }
                 }
             } else {
                 $post['has_file'] = false;
@@ -1597,10 +1597,10 @@ function mod_merge($originBoard, $postID) {
                 $post['files'] = json_decode($post['files'], TRUE);
                 $post['has_file'] = true;
                 foreach ($post['files'] as $i => &$file) {
-                    if ($file['file'] === 'deleted')
-                        continue;
-                    $file['file_path'] = sprintf($config['board_path'], $board['uri']) . $config['dir']['img'] . $file['file'];
-                    $file['thumb_path'] = sprintf($config['board_path'], $board['uri']) . $config['dir']['thumb'] . $file['thumb'];
+                    if ($file['file'] !== 'deleted')
+                        $file['file_path'] = sprintf($config['board_path'], $board['uri']) . $config['dir']['img'] . $file['file'];
+                    if (isset($file['thumb']) && !in_array($file['thumb'], array('spoiler', 'deleted', 'file')))
+                        $file['thumb_path'] = sprintf($config['board_path'], $board['uri']) . $config['dir']['thumb'] . $file['thumb'];
                 }
             } else {
                 $post['has_file'] = false;
@@ -1647,8 +1647,10 @@ function mod_merge($originBoard, $postID) {
                     $post['files'] = json_decode($post['files'], TRUE);
                     $post['has_file'] = true;
                     foreach ($post['files'] as $i => &$file) {
-                        $file['file_path'] = sprintf($config['board_path'], $board['uri']) . $config['dir']['img'] . $file['file'];
-                        $file['thumb_path'] = sprintf($config['board_path'], $board['uri']) . $config['dir']['thumb'] . $file['thumb'];
+                        if ($file['file'] !== 'deleted')
+                            $file['file_path'] = sprintf($config['board_path'], $board['uri']) . $config['dir']['img'] . $file['file'];
+                        if (isset($file['thumb']) && !in_array($file['thumb'], array('spoiler', 'deleted', 'file')))
+                            $file['thumb_path'] = sprintf($config['board_path'], $board['uri']) . $config['dir']['thumb'] . $file['thumb'];
                     }
                 } else {
                     $post['has_file'] = false;
@@ -1687,8 +1689,10 @@ function mod_merge($originBoard, $postID) {
                 if ($post['has_file']) {
                     // copy image
                     foreach ($post['files'] as $i => &$file) {
-                        clone_wrapped_with_exist_check($clone, $file['file_path'], sprintf($config['board_path'], $board['uri']) . $config['dir']['img'] . $file['file']);
-                        clone_wrapped_with_exist_check($clone, $file['thumb_path'], sprintf($config['board_path'], $board['uri']) . $config['dir']['thumb'] . $file['thumb']);
+                        if ($file['file'] !== 'deleted')
+                            clone_wrapped_with_exist_check($clone, $file['file_path'], sprintf($config['board_path'], $board['uri']) . $config['dir']['img'] . $file['file']);
+                        if (isset($file['thumb']) && !in_array($file['thumb'], array('spoiler', 'deleted', 'file')))
+                            clone_wrapped_with_exist_check($clone, $file['thumb_path'], sprintf($config['board_path'], $board['uri']) . $config['dir']['thumb'] . $file['thumb']);
                     }
                 }
                 // insert reply


### PR DESCRIPTION
Moving posts or threads with unusual files or thumbnails can cause errors, potentially breaking threads. This handles these cases more completely.

note: this still breaks thread moving, don't pull as is