### PR TITLE
Fix typos in https://github.com/towards-a-new-leftypol/leftypol_lainchan/pull/336

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -1154,7 +1154,7 @@
     $config['error']['nodelete']        = _('You didn\'t select anything to delete.');
     $config['error']['nodeletethread']  = _('You are not allowed to delete threads.');
     $config['error']['noreport']        = _('You didn\'t select anything to report.');
- 	$config['error']['toolongreport']	= _('The reason was too long.');
+    $config['error']['toolongreport']	= _('The reason was too long.');
     $config['error']['toomanyreports']  = _('You can\'t report that many posts at once.');
     $config['error']['invalidpassword'] = _('Wrong password…');
     $config['error']['invalidimg']      = _('Invalid image.');

--- a/post.php
+++ b/post.php
@@ -320,7 +320,7 @@ function handle_report(){
         error($config['error']['noreport']);
     
     if (strlen($_POST['reason']) > $config['report_max_length'])
-        error($config['error']['reporttoolong']);
+        error($config['error']['toolongreport']);
     
     if (count($report) > $config['report_limit'])
         error($config['error']['toomanyreports']);


### PR DESCRIPTION
Forcing a report message larger than the character limit will fail to find the given error message due to a typo.