### PR TITLE
Fix annoying autofill behaviour for Safari

### DIFF
--- a/templates/report_delete.html
+++ b/templates/report_delete.html
@@ -2,8 +2,8 @@
 	{% if config.allow_delete %}
 	<div id="delete-fields">
 		{% trans %}Delete Post{% endtrans %} [<input title="Delete file only" type="checkbox" name="file" id="delete_file" />
-		 <label for="delete_file">{% trans %}File{% endtrans %}</label>] <label for="password">{% trans %}Password{% endtrans %}</label> 
-		<input id="password" type="password" name="password" size="12" maxlength="18" />
+		<label for="delete_file">{% trans %}File{% endtrans %}</label>] <label for="password">{% trans %}Password{% endtrans %}</label> 
+		<input id="password" type="password" name="password" autocomplete="new-password" size="12" maxlength="18" />
 		<input type="submit" name="delete" value="{% trans %}Delete{% endtrans %}" />
 	</div>
 	{% endif %}


### PR DESCRIPTION
*Should* stop Safari on iOS from autofocusing the post password input.