### PR TITLE
recent_posts.js: Rework

### DIFF
--- a/js/lcn/utils.js
+++ b/js/lcn/utils.js
@@ -31,3 +31,19 @@ const assert = {
         }
     }
 }
+
+AbortSignal.any ??= function (signals) {
+    const controller = new AbortController()
+    const abortFn = () => {
+        for (const signal of signals) {
+            signal.removeEventListener("abort", abortFn)
+        }
+        controller.abort()
+    }
+
+    for (const signal of signals) {
+        signal.addEventListener("abort", abortFn)
+    }
+
+    return controller.signal
+}

--- a/js/mod/recent_posts.js
+++ b/js/mod/recent_posts.js
@@ -74,7 +74,7 @@ $().ready(() => {
                         }
 
                         updatePageNext()
-                        LCNSite.INSTANCE.setUnseen(LCNSite.INSTANCE.getUnseen() + postWrapper.length)
+                        LCNSite.INSTANCE.setUnseen(LCNSite.INSTANCE.getUnseen() + postWrappers.length)
                     }
                   })
                   .catch(error => {

--- a/js/mod/recent_posts.js
+++ b/js/mod/recent_posts.js
@@ -1,190 +1,163 @@
 /**
- * Implements live-reloading on the recent posts mod page.
+ * @file Implements live-reloading on the recent posts mod page.
+ * @author jonsmy
  */
-(() => {
-    if (AbortSignal.any === undefined) {
-        AbortSignal.any = function (signals) {
-            const controller = new AbortController()
-            const abortFn = () => {
-                for (const signal of signals) {
-                    signal.removeEventListener("abort", abortFn)
-                }
-                controller.abort()
-            }
-
-            for (const signal of signals) {
-                signal.addEventListener("abort", abortFn)
-            }
-
-            return controller.signal
+$().ready(() => {
+    if (LCNSite.INSTANCE.isModRecentsPage()) {
+        const loadIntFromStorage = key => {
+            const value = localStorage.getItem(`jon-liveposts::${key}`)
+            return value != null ? parseInt(value) : null
         }
-    }
 
-    const scriptFn = () => {
-        const kLocationPath = location.href.slice(location.origin.length)
-        if (/^\/mod\.php\?\/recent\/\d+$/.test(kLocationPath)) {
-            const loadIntFromStorage = key => {
-                const value = localStorage.getItem(`jon-liveposts::${key}`)
-                return value != null ? parseInt(value) : null
-            }
+        const kPullXPosts = loadIntFromStorage("pull-x-posts") ?? 6
+        const kPullEveryX = loadIntFromStorage("pull-every-x") ?? 8000
+        const kRecentXPosts = parseInt(location.search.slice(9).split(/[^\d]/)[0])
+        const kWasEnabled = loadIntFromStorage("enabled") == 1
+        const kBellWasEnabled = loadIntFromStorage("bell-enabled") == 1
 
-            const kPullXPosts = loadIntFromStorage("pull-x-posts") ?? 6
-            const kPullEveryX = loadIntFromStorage("pull-every-x") ?? 8000
-            const kRecentXPosts = parseInt(kLocationPath.slice(17).split(/[^\d]/)[0])
-            const kWasEnabled = loadIntFromStorage("enabled") == 1
-            const kBellWasEnabled = loadIntFromStorage("bell-enabled") == 1
+        let liveUpdateEnabled = false
+        let liveUpdateBellEnabled = kBellWasEnabled
+        let liveUpdateAbortController = null
+        let liveUpdateIntervalId = null
+        let liveUpdateFaviconChanged = false
 
-            let liveUpdateEnabled = false
-            let liveUpdateBellEnabled = kBellWasEnabled
-            let liveUpdateAbortController = null
-            let liveUpdateIntervalId = null
-            let liveUpdateFaviconChanged = false
-
-            const parser = new DOMParser()
-            const fetchLatest = async () => {
-                const res = await fetch(`/mod.php?/recent/${kPullXPosts}`, {
-                    "signal": AbortSignal.any([ liveUpdateAbortController.signal, AbortSignal.timeout(kPullEveryX - 500) ])
-                })
-
-                if (res.ok) {
-                    const dom = parser.parseFromString(await res.text(), "text/html")
-                    const posts = Array.from(dom.querySelectorAll("body > .post-wrapper[data-board]"))
-                    const eita = Array.prototype.find.apply(el.children, [ el => el.classList.contains("eita-link") ])
-                    return posts.map(el => ({
-                        "element": el,
-                        "post": el.querySelector(".thread, .post"),
-                        "href": eita.href,
-                        "id": eita.id
-                    }))
-                } else {
-                    return []
-                }
-            }
-
-            const getPostTimestamp = post => new Date(post.lastElementChild.querySelector(".intro time").dateTime)
-            const updateRecentPosts = () => {
-                if (liveUpdateEnabled) {
-                    fetchLatest()
-                      .then(latestPosts => {
-                        const lastPost = Array.prototype.find.apply(document.body.children, [ el => el.classList.contains("post-wrapper") ])
-                        const lastPostTs = getPostTimestamp(lastPost).getTime()
-                        const posts = latestPosts.filter(post => document.getElementById(post.id) == null && getPostTimestamp(post.element).getTime() > lastPostTs)
-                        if (posts.length > 0) {
-                            const totalPosts = Array.from(document.body.querySelectorAll(".post-wrapper"))
-                            for (const post of posts) {
-                                document.body.insertBefore(post.element, lastPost)
-                                totalPosts.unshift(post.element)
-                            }
-
-                            while (totalPosts.length > kRecentXPosts) {
-                                document.body.removeChild(totalPosts.pop())
-                            }
-
-                            // XXX: Fire ::new_post for chanx listeners
-                            for (const post of posts.slice(0, kRecentXPosts)) {
-                                $(document).trigger("new_post", [ post.post ])
-                            }
-
-                            updatePageNext()
-                            makeIcon("reply")
-                            liveUpdateFaviconChanged = true
-                        }
-                      })
-                      .catch(error => {
-                        // XXX: Why the hell does gecko have a space at the end??
-                        if (!((error instanceof DOMException) && [ "The user aborted a request", "The operation was aborted." ].some(msg => error.message.slice(0, 26) === msg))) {
-                            throw error
-                        }
-                      })
-                }
-            }
-
-            const pageNext = Array.prototype.find.apply(document.body.children, [ el => el.nodeName == "A" && el.href.startsWith(`${location.origin}/mod.php?/recent/${kRecentXPosts}&last=`) ])
-            const updatePageNext = () => {
-                const posts = document.body.querySelectorAll(".post-wrapper")
-                const oldestPost = posts[posts.length-1]
-                pageNext.href = `/mod.php?/recent/${kRecentXPosts}&last=${getPostTimestamp(oldestPost).getTime() / 1000}`
-            }
-
-            const createCheckbox = (id, text, initialState) => {
-                const div = document.createElement("div")
-                const label = document.createElement("label")
-                const checkbox = document.createElement("input")
-                checkbox.type = "checkbox"
-                checkbox.id = id
-                checkbox.checked = initialState
-                label.innerText = text
-                label.for = id
-                div.style.display = "inline"
-                div.append(" ")
-                div.appendChild(label)
-                div.appendChild(checkbox)
-                div.append(" ")
-                return { checkbox, label, div }
-            }
-
-            const liveUpdateToggle = enabled => {
-                if (enabled) {
-                    liveUpdateEnabled = true
-                    liveUpdateAbortController = new AbortController()
-                    liveUpdateIntervalId = setInterval(() => updateRecentPosts(), kPullEveryX)
-                } else {
-                    liveUpdateEnabled = false
-                    clearInterval(liveUpdateIntervalId)
-                    liveUpdateAbortController.abort()
-                    liveUpdateIntervalId = null
-                    liveUpdateAbortController = null
-                }
-
-                if (kLiveForm.checkbox.checked != enabled) {
-                    kLiveForm.checkbox.checked = enabled
-                }
-            }
-
-            const pageNums = Array.prototype.find.apply(document.body.children, [ el => el.nodeName == "P" ])
-            const kLiveForm = createCheckbox("jon-liveposts-enabled", "live: ", kWasEnabled)
-            const kBellForm = createCheckbox("jon-liveposts-bell-enabled", "beep: ", kBellWasEnabled)
-            const kBell = new Audio("/static/jannybell.mp3")
-
-            kLiveForm.checkbox.addEventListener("change", () => {
-                localStorage.setItem("jon-liveposts::enabled", kLiveForm.checkbox.checked ? "1" : "0")
-                liveUpdateToggle(kLiveForm.checkbox.checked)
+        const parser = new DOMParser()
+        const fetchRecentPosts = async () => {
+            const res = await fetch(`/mod.php?/recent/${kPullXPosts}`, {
+                "signal": AbortSignal.any([ liveUpdateAbortController.signal, AbortSignal.timeout(kPullEveryX - 500) ])
             })
 
-            kBellForm.checkbox.addEventListener("change", () => {
-                localStorage.setItem("jon-liveposts::bell-enabled", kBellForm.checkbox.checked ? "1" : "0")
-                liveUpdateBellEnabled = kBellForm.checkbox.checked
-            })
-
-            $(document).on("new_post", () => {
-                if (liveUpdateBellEnabled && kBell.paused) {
-                    // XXX: Site requires autoplay media permission to do this
-                    kBell.play().catch(console.error)
-                }
-            })
-
-            for (const form of [ kLiveForm, kBellForm ]) {
-                pageNums.append("|")
-                pageNums.append(form.div)
-            }
-
-            document.body.addEventListener("mousemove", () => {
-                if (liveUpdateFaviconChanged) {
-                    liveUpdateFaviconChanged = false
-                    makeIcon(false)
-                }
-            })
-
-            if (kWasEnabled) {
-                setTimeout(() => liveUpdateToggle(true), 1)
+            if (res.ok) {
+                const dom = parser.parseFromString(await res.text(), "text/html")
+                return dom.querySelectorAll("body > .post-wrapper")
+            } else {
+                return []
             }
         }
-    }
 
+        const fetchLatestPosts = async () => {
+            const postWrappers = LCNPostWrapper.all()
+            const lastPostWrapper = LCNPostWrapper.assign(document.body.querySelector(".post-wrapper"))
+            const lastPostTs = lastPostWrapper.getPost().getInfo().getCreatedAt().getTime()
+            const missingPosts = []
+            for (const element of await fetchRecentPosts()) {
+                const postWrapper = LCNPostWrapper.assign(element)
+                const postInfo = postWrapper.getPost().getInfo()
+                if (postInfo.getCreatedAt().getTime() > lastPostTs && !postWrappers.some(pw => pw.getPost().getInfo().is(postInfo))) {
+                    missingPosts.unshift(postWrapper)
+                } else {
+                    break
+                }
+            }
 
-    if (document.readyState != "complete") {
-        window.addEventListener("load", scriptFn, { "once": true })
-    } else {
-        setTimeout(scriptFn, 1)
+            return missingPosts
+        }
+
+        const updateRecentPosts = () => {
+            if (liveUpdateEnabled) {
+                const totalPosts = LCNPostWrapper.all()
+                fetchLatestPosts()
+                  .then(postWrappers => {
+                    if (postWrappers.length > 0) {
+                        for (const postWrapper of postWrappers) {
+                            document.body.insertBefore(postWrapper.getElement(), totalPosts[0].getElement())
+                            totalPosts.unshift(postWrapper)
+                        }
+
+                        while (totalPosts.length > kRecentXPosts) {
+                            document.body.removeChild(totalPosts.pop().getElement())
+                        }
+
+                        // XXX: Fire ::new_post for chanx listeners
+                        for (const postWrapper of postWrappers.slice(0, kRecentXPosts).reverse()) {
+                            $(document).trigger("new_post", [ postWrapper.getPost().getElement() ])
+                        }
+
+                        updatePageNext()
+                        LCNSite.INSTANCE.setUnseen(LCNSite.INSTANCE.getUnseen() + postWrapper.length)
+                    }
+                  })
+                  .catch(error => {
+                    // XXX: Why the hell does gecko have a space at the end??
+                    if (!((error instanceof DOMException) && [ "The user aborted a request", "The operation was aborted." ].some(msg => error.message.slice(0, 26) === msg))) {
+                        throw error
+                    }
+                  })
+            }
+        }
+
+        const pageNext = Array.prototype.find.apply(document.body.children, [ el => el.nodeName == "A" && el.href.startsWith(`${location.origin}/mod.php?/recent/${kRecentXPosts}&last=`) ])
+        const updatePageNext = () => {
+            const oldestPostInfo = LCNPostWrapper.all().at(-1).getContent().getContent().getInfo()
+            pageNext.href = `/mod.php?/recent/${kRecentXPosts}&last=${oldestPostInfo.getCreatedAt().getTime() / 1000}`
+        }
+
+        const createCheckbox = (id, text, initialState) => {
+            const div = document.createElement("div")
+            const label = document.createElement("label")
+            const checkbox = document.createElement("input")
+            checkbox.type = "checkbox"
+            checkbox.id = id
+            checkbox.checked = initialState
+            label.innerText = text
+            label.for = id
+            div.style.display = "inline"
+            div.append(" ")
+            div.appendChild(label)
+            div.appendChild(checkbox)
+            div.append(" ")
+            return { checkbox, label, div }
+        }
+
+        const liveUpdateToggle = enabled => {
+            if (enabled) {
+                liveUpdateEnabled = true
+                liveUpdateAbortController = new AbortController()
+                liveUpdateIntervalId = setInterval(() => updateRecentPosts(), kPullEveryX)
+            } else {
+                liveUpdateEnabled = false
+                clearInterval(liveUpdateIntervalId)
+                liveUpdateAbortController.abort()
+                liveUpdateIntervalId = null
+                liveUpdateAbortController = null
+            }
+
+            if (kLiveForm.checkbox.checked != enabled) {
+                kLiveForm.checkbox.checked = enabled
+            }
+        }
+
+        const pageNums = Array.prototype.find.apply(document.body.children, [ el => el.nodeName == "P" ])
+        const kLiveForm = createCheckbox("jon-liveposts-enabled", "live: ", kWasEnabled)
+        const kBellForm = createCheckbox("jon-liveposts-bell-enabled", "bell: ", kBellWasEnabled)
+        const kBell = new Audio("/static/jannybell.mp3")
+
+        kLiveForm.checkbox.addEventListener("change", () => {
+            localStorage.setItem("jon-liveposts::enabled", kLiveForm.checkbox.checked ? "1" : "0")
+            liveUpdateToggle(kLiveForm.checkbox.checked)
+        })
+
+        kBellForm.checkbox.addEventListener("change", () => {
+            localStorage.setItem("jon-liveposts::bell-enabled", kBellForm.checkbox.checked ? "1" : "0")
+            liveUpdateBellEnabled = kBellForm.checkbox.checked
+        })
+
+        $(window).on("focus", () => LCNSite.INSTANCE.clearUnseen())
+        $(document.body).on("mousemove", () => LCNSite.INSTANCE.clearUnseen())
+        $(document).on("new_post", () => {
+            if (liveUpdateBellEnabled && kBell.paused) {
+                // XXX: Site requires autoplay media permission to do this
+                kBell.play().catch(console.error)
+            }
+        })
+
+        for (const form of [ kLiveForm, kBellForm ]) {
+            pageNums.append("|")
+            pageNums.append(form.div)
+        }
+
+        if (kWasEnabled) {
+            setTimeout(() => liveUpdateToggle(true), 1)
+        }
     }
-})()
+})


### PR DESCRIPTION
- Replace janky dom extraction with less janky asserted dom extraction.
- Use `LCNSite.setUnseen` instead of `makeIcon`. The number of new posts now appears in the page title
- Bind `window::focus` for dismissing new posts instead of just relying on mouse movement